### PR TITLE
MagicWord -> MagicWordFactory

### DIFF
--- a/NumberedHeadings.class.php
+++ b/NumberedHeadings.class.php
@@ -25,9 +25,9 @@ class NumberedHeadings
         &$text,
         &$strip_state
     ) {
-        if (MagicWordFactory::get('MAG_NUMBEREDHEADINGS')->matchAndRemove($text)) {
+        if (MediaWiki\MediaWikiServices::getInstance()->getMagicWordFactory()->get('MAG_NUMBEREDHEADINGS')->matchAndRemove($text)) {
             $parser->mOptions->setNumberHeadings(true);
-        } elseif (MagicWordFactory::get('MAG_NONUMBEREDHEADINGS')->matchAndRemove($text)) {
+        } elseif (MediaWiki\MediaWikiServices::getInstance()->getMagicWordFactory()->get('MAG_NONUMBEREDHEADINGS')->matchAndRemove($text)) {
             $parser->mOptions->setNumberHeadings(false);
         }
         return true;

--- a/NumberedHeadings.class.php
+++ b/NumberedHeadings.class.php
@@ -25,9 +25,9 @@ class NumberedHeadings
         &$text,
         &$strip_state
     ) {
-        if (MagicWord::get('MAG_NUMBEREDHEADINGS')->matchAndRemove($text)) {
+        if (MagicWordFactory::get('MAG_NUMBEREDHEADINGS')->matchAndRemove($text)) {
             $parser->mOptions->setNumberHeadings(true);
-        } elseif (MagicWord::get('MAG_NONUMBEREDHEADINGS')->matchAndRemove($text)) {
+        } elseif (MagicWordFactory::get('MAG_NONUMBEREDHEADINGS')->matchAndRemove($text)) {
             $parser->mOptions->setNumberHeadings(false);
         }
         return true;


### PR DESCRIPTION
MagicWord::get was removed in 1.35 but deprecated in 1.32

https://github.com/wikimedia/mediawiki/commit/112b6f305b01ef8e50676ca6d7f7cd5b8b43610c